### PR TITLE
Allow custom time formatting

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -80,27 +80,46 @@
 		return NULL;
 	}
 
-	function formatTime($time) {
+	function formatTime($time, $format = 'DEFAULT') {
 		if ($time === FALSE) { return ''; }
 
-		$newms = preg_replace('/^[0-9]+\./', '', sprintf('%s', $time));
-		if ($newms == $time) { $newms = ''; }
+		switch (strtoupper($format)) {
+			case 'SECONDS':
+				return sprintf('%ss', number_format($time/1000, 3));
 
-		$m = $s = $ms = 0;
+			case 'MILLISECONDS':
+				return sprintf('%sms', number_format($time, 3));
 
-		if ($time > 60 * 1000) {
-			$m = floor($time / (60 * 1000));
-			$time -= ((int)$m) * 60 * 1000;
+			case 'MICROSECONDS':
+				return sprintf('%sμs', number_format($time*1000, 3));
+
+			case 'NANOSECONDS':
+				return sprintf('%sns', number_format($time*1000*1000, 3));
+
+			case 'PICOSECONDS':
+			case 'FULL':
+				return sprintf('%sps', number_format($time*1000*1000*1000, 0));
+
+			case 'DEFAULT':
+			default:
+				$newms = preg_replace('/^[0-9]+\./', '', sprintf('%s', $time));
+				if ($newms == $time) { $newms = ''; }
+
+				$m = $s = $ms = 0;
+
+				if ($time > 60 * 1000) {
+					$m = floor($time / (60 * 1000));
+					$time -= ((int)$m) * 60 * 1000;
+				}
+
+				if ($time > 1000) {
+					$s = floor($time / (1000));
+					$time -= $s * 1000;
+				}
+
+				$ms = $time;
+				return sprintf('%dm%d.%03d%ss', $m, $s, $ms, $newms);
 		}
-
-		if ($time > 1000) {
-			$s = floor($time / (1000));
-			$time -= $s * 1000;
-		}
-
-		$ms = $time;
-
-		return sprintf('%dm%d.%03d%ss', $m, $s, $ms, $newms);
 	}
 
 	function getSortedTimes($times, $format = true) {

--- a/www/index.php
+++ b/www/index.php
@@ -7,6 +7,7 @@
 
 
 	$method = isset($_REQUEST['method']) ? $_REQUEST['method'] : 'MEDIAN';
+	$timeFormat = isset($_REQUEST['times']) ? $_REQUEST['times'] : 'DEFAULT';
 	$lang = isset($_REQUEST['lang']) ? (is_array($_REQUEST['lang']) ? $_REQUEST['lang'] : [$_REQUEST['lang']]) : True;
 
 	if ($hasResults) {
@@ -15,18 +16,42 @@
 		$langLink = '';
 		if ($lang !== True) {
 			foreach ($lang as $l) {
-				$langLink .= '&lang[]=' . urlencode($l);
+				$langLink .= '&amp;lang[]=' . urlencode($l);
 			}
 		}
 
-		foreach (['MEDIAN' => 'Median', 'MIN' => 'Minimum', 'Mean' => 'Mean', 'SPECIAL' => 'MeanBest', 'MAX' => 'Maximum'] as $m => $title) {
-			$link = '<a href="?method=' . $m . $langLink . '">' . $title . '</a>';
-			if ($m == $method) { $link = '<strong>' . $link . '</strong>'; }
-
-			$links[] = $link;
+		$methodLink = '';
+		if ($method !== 'MEDIAN') {
+			$methodLink = '&amp;method=' . urlencode($method);
 		}
+
+		$timeLink = '';
+		if ($timeFormat !== 'DEFAULT') {
+			$timeLink = '&amp;times=' . urlencode($timeFormat);
+		}
+
+		$averagingLinks = [];
+		foreach (['MEDIAN' => 'Median', 'MIN' => 'Minimum', 'Mean' => 'Mean', 'SPECIAL' => 'MeanBest', 'MAX' => 'Maximum'] as $m => $title) {
+			$link = '<a href="?method=' . $m . $langLink . $timeLink . '">' . $title . '</a>';
+			if (strtoupper($m) == strtoupper($method)) { $link = '<strong>' . $link . '</strong>'; }
+
+			$averagingLinks[] = $link;
+		}
+
+		$timeLinks = [];
+		foreach (['DEFAULT' => 'Default', 'SECONDS' => 's', 'MILLISECONDS' => 'ms', 'MICROSECONDS' => 'μs', 'NANOSECONDS' => 'ns', 'PICOSECONDS' => 'ps'] as $m => $title) {
+			$link = '<a href="?times=' . $m . $langLink . $methodLink . '">' . $title . '</a>';
+			if (strtoupper($m) == strtoupper($timeFormat)) { $link = '<strong>' . $link . '</strong>'; }
+
+			$timeLinks[] = $link;
+		}
+
 		echo '<p class="text-muted text-right">';
-		echo '<small>', implode(' - ', $links), '</small>';
+		echo '<small>';
+		echo '<strong>Averaging:</strong> ', implode(' - ', $averagingLinks);
+		echo ' &middot; ';
+		echo '<strong>Times:</strong> ', implode(' - ', $timeLinks);
+		echo '</small>';
 		echo '</p>';
 
 		echo '<table class="table table-striped">';
@@ -130,7 +155,7 @@
 					$min = isset($pdata['days'][$day]['times']) ? getParticipantTime($pdata['days'][$day]['times'], 'MIN') : '';
 					$max = isset($pdata['days'][$day]['times']) ? getParticipantTime($pdata['days'][$day]['times'], 'MAX') : '';
 
-					$tooltip = 'Min: ' . formatTime($min) . '<br>' . 'Max: ' . formatTime($max);
+					$tooltip = 'Min: ' . formatTime($min, $timeFormat) . '<br>' . 'Max: ' . formatTime($max, $timeFormat);
 
 					$classes = ['participant', 'time'];
 					if ($podium) {
@@ -153,7 +178,7 @@
 					if (!$podium && $time == $podiumTime['first']) { $classes[] = 'table-best'; }
 
 					echo '<td class="', implode(' ', $classes), '" data-ms="', $time ,'" data-toggle="tooltip" data-placement="bottom" data-html="true" title="', htmlspecialchars($tooltip), '">';
-					echo formatTime($time);
+					echo formatTime($time, $timeFormat);
 					echo '</td>';
 				} else {
 					echo '<td class="participant">&nbsp;</td>';


### PR DESCRIPTION
Add a new switcheroo along side the averaging one to select between:

- default (the existing "0m0.0000123s" format
- seconds, milliseconds, microseconds, nanoseconds which all display the number to 3 decimal places with thousand separators
- picoseconds, which is the same but without any decimals because we can't count that small

Closes #19

# Preview

![Screenshot_20231210_212648](https://github.com/ShaneMcC/AoCBench/assets/189133/1b497994-4de4-4dd7-9e1e-7dfaf84367e8)
![Screenshot_20231210_212637](https://github.com/ShaneMcC/AoCBench/assets/189133/9b22a6b7-b794-41a7-9b33-f03f651bfc94)
