### PR TITLE
Add links to jump to a specific day on matrix page

### DIFF
--- a/www/matrix.php
+++ b/www/matrix.php
@@ -11,6 +11,27 @@
 
 	$_SESSION['lang'] = $lang;
 
+	echo '<p class="text-muted text-right sticky">';
+	echo '<small><strong>Jump to day:</strong> ';
+	if ($hasMatrix) {
+		for ($day = 1; $day <= 25; $day++) {
+			foreach ($matrix['results'] as $data) {
+				if (isset($data['days'][$day])) {
+					$dayLinks []= ' <a href="#day' . $day . '">' . $day . '</a>';
+					break;
+				}
+			}
+		}
+	}
+
+	if (empty($dayLinks)) {
+		echo 'None available';
+	} else {
+		echo implode(' - ', $dayLinks);
+	}
+	echo '</small>';
+	echo '</p>';
+
 	if ($lang != ['*']) {
 		echo '<p class="text-muted text-right">';
 		echo '<small>';
@@ -81,7 +102,7 @@
 
 			if (!$hasDay) { continue; }
 
-			echo '<h2>Day ', $day, '</h2>', "\n";
+			echo '<h2 id="day', $day, '">Day ', $day, '</h2>', "\n";
 			if (isset($leaderboardYear) && !empty($leaderboardYear)) {
 				echo '<a href="https://adventofcode.com/', (isset($leaderboardYear) ? $leaderboardYear : date('Y')), '/day/', $day, '">Problem</a><br><br>';
 			}

--- a/www/style.css
+++ b/www/style.css
@@ -67,3 +67,8 @@ a.daylink {
 pre {
   line-height: 1.1em;
 }
+
+.sticky {
+  position: sticky;
+  top: 55px;
+}


### PR DESCRIPTION
Add a list of days in the top right to allow quick navigation.

# Preview

When scrolled up it sits where the filters go:

![Screenshot_20231210_225604](https://github.com/ShaneMcC/AoCBench/assets/189133/a4a31cf8-da86-4761-a271-c8b634cd7c48)

As you scroll down it docks under the nav bar:

![Screenshot_20231210_225619](https://github.com/ShaneMcC/AoCBench/assets/189133/cb287279-0cbd-4dc5-8076-12dc751f4b3f)
