### PR TITLE
Align times better

### DIFF
--- a/www/style.css
+++ b/www/style.css
@@ -60,6 +60,12 @@ table {
     background-color: #DCA671;
 }
 
+table .time {
+    vertical-align: middle;
+    text-align: right;
+    padding: .5rem;
+}
+
 a.daylink {
   color: #212529;
 }


### PR DESCRIPTION
Times are numeric table cells so should be aligned to the decimal point (so that digits with identical place-value line up vertically). Since all numbers shown have identical decimal places, this can be accomplished by right-aligning them.

At the same time, vertically centring numbers within cells looks nice. Removing some padding should help when there are many participants with long times on smaller screens.